### PR TITLE
Ignore records with association already loaded

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,1 @@
-eval_gemfile(File.expand_path('gemfiles/rails3.2.gemfile', __dir__))
+eval_gemfile('gemfiles/rails3.2.gemfile')

--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,1 @@
-eval_gemfile('gemfiles/rails3.2.gemfile')
+eval_gemfile(File.expand_path('gemfiles/rails3.2.gemfile', __dir__))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: /harmony/code/predictive_load
+  remote: .
   specs:
     predictive_load (0.4.1)
       activerecord (>= 3.2.0, < 5.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: .
+  remote: /harmony/code/predictive_load
   specs:
     predictive_load (0.4.1)
       activerecord (>= 3.2.0, < 5.1)
@@ -52,4 +52,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.11.2
+   1.16.1

--- a/gemfiles/rails3.2.gemfile
+++ b/gemfiles/rails3.2.gemfile
@@ -1,4 +1,4 @@
-eval_gemfile(File.expand_path('common.rb', __dir__))
+eval_gemfile('common.rb')
 
 gem 'activerecord', '~> 3.2.22'
 gem 'test-unit-minitest'

--- a/gemfiles/rails3.2.gemfile
+++ b/gemfiles/rails3.2.gemfile
@@ -1,4 +1,4 @@
-eval_gemfile('gemfiles/common.rb')
+eval_gemfile(File.expand_path('common.rb', __dir__))
 
 gem 'activerecord', '~> 3.2.22'
 gem 'test-unit-minitest'

--- a/gemfiles/rails4.1.gemfile
+++ b/gemfiles/rails4.1.gemfile
@@ -1,3 +1,3 @@
-eval_gemfile(File.expand_path('common.rb', __dir__))
+eval_gemfile('common.rb')
 
 gem 'activerecord', '~> 4.1.14'

--- a/gemfiles/rails4.1.gemfile
+++ b/gemfiles/rails4.1.gemfile
@@ -1,3 +1,3 @@
-eval_gemfile('gemfiles/common.rb')
+eval_gemfile(File.expand_path('common.rb', __dir__))
 
 gem 'activerecord', '~> 4.1.14'

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,3 +1,3 @@
-eval_gemfile(File.expand_path('common.rb', __dir__))
+eval_gemfile('common.rb')
 
 gem 'activerecord', '~> 4.2.5'

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,3 +1,3 @@
-eval_gemfile('gemfiles/common.rb')
+eval_gemfile(File.expand_path('common.rb', __dir__))
 
 gem 'activerecord', '~> 4.2.5'

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,3 +1,3 @@
-eval_gemfile('gemfiles/common.rb')
+eval_gemfile(File.expand_path('common.rb', __dir__))
 
 gem 'activerecord', '~> 5.0.0.beta2'

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,3 +1,3 @@
-eval_gemfile(File.expand_path('common.rb', __dir__))
+eval_gemfile('common.rb')
 
 gem 'activerecord', '~> 5.0.0.beta2'

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(:version => 1) do
   create_table(:comments) do |t|
     t.string   :body,     :null => false
     t.integer  :topic_id, :null => false
-    t.integer  :user_id,  :null => false
+    t.integer  :user_id,  :null => true
     t.boolean  :public,   :null => false, :default => true
     t.timestamps(null: false)
   end


### PR DESCRIPTION
https://github.com/rails/rails/blob/v4.2.10/activerecord/lib/active_record/associations/preloader.rb#L187 (similar to other Rails versions)
If the first record association is loaded, Preloader aborts.

In a code like `comments.each { |c| c.user }`, if the first comment user_id is nil,
when calling the method (`user`) ActiveRecord doesn't load the association, but marks it as loaded.
So when the second comment calls `user` (and user_id is not nil), `@records.first` will be the first
comment above (with thr association already loaded), which will be checked by Preloader and used to skip
any preloading.

Fix is pretty simple, ignore any record with association already loaded.

### Risks
Medium. Might degrade performance if there are too many records being preloaded and no preloading needed.