### PR TITLE
[R5U-2228] update cross gem compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: /Users/pschambacher/Code/zendesk/predictive_load
+  remote: .
   specs:
     predictive_load (0.5.0)
       activerecord (>= 4.2.0, < 5.3)

--- a/gemfiles/common.rb
+++ b/gemfiles/common.rb
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gemspec path: Bundler.root.sub('/gemfiles', '')
+gemspec path: '..'
 
 gem 'minitest'
 gem 'minitest-rg'

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -1,48 +1,45 @@
 PATH
-  remote: /Users/mgrosser/Code/tools/predictive_load
+  remote: ..
   specs:
-    predictive_load (0.3.2)
-      activerecord (>= 3.2.0, < 5.1)
+    predictive_load (0.5.0)
+      activerecord (>= 4.2.0, < 5.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.0.0.beta2)
-      activesupport (= 5.0.0.beta2)
-    activerecord (5.0.0.beta2)
-      activemodel (= 5.0.0.beta2)
-      activesupport (= 5.0.0.beta2)
+    activemodel (5.0.7.2)
+      activesupport (= 5.0.7.2)
+    activerecord (5.0.7.2)
+      activemodel (= 5.0.7.2)
+      activesupport (= 5.0.7.2)
       arel (~> 7.0)
-    activesupport (5.0.0.beta2)
-      concurrent-ruby (~> 1.0)
-      i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
-      method_source
+    activesupport (5.0.7.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    arel (7.0.0)
-    bump (0.5.3)
-    byebug (8.2.2)
-    concurrent-ruby (1.0.0)
-    i18n (0.7.0)
-    json (1.8.3)
-    method_source (0.8.2)
-    minitest (5.8.4)
+    arel (7.1.4)
+    bump (0.10.0)
+    byebug (11.1.3)
+    concurrent-ruby (1.1.9)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.4)
     minitest-rg (5.2.0)
       minitest (~> 5.0)
-    query_diet (0.6.0)
-    rake (10.5.0)
-    sqlite3 (1.3.11)
-    thread_safe (0.3.5)
-    tzinfo (1.2.2)
+    query_diet (0.7.0)
+    rake (13.0.6)
+    sqlite3 (1.3.13)
+    thread_safe (0.3.6)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
-    wwtd (1.3.0)
+    wwtd (1.4.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (~> 5.0.0.beta2)
+  activerecord (~> 5.0.0)
   bump
   byebug
   minitest
@@ -50,8 +47,8 @@ DEPENDENCIES
   predictive_load!
   query_diet
   rake
-  sqlite3
+  sqlite3 (~> 1.3, < 1.4)
   wwtd
 
 BUNDLED WITH
-   1.11.2
+   1.17.2

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -7,31 +7,29 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.11.3)
-      activesupport (= 4.2.11.3)
-      builder (~> 3.1)
-    activerecord (4.2.11.3)
-      activemodel (= 4.2.11.3)
-      activesupport (= 4.2.11.3)
-      arel (~> 6.0)
-    activesupport (4.2.11.3)
-      i18n (~> 0.7)
+    activemodel (5.1.7)
+      activesupport (= 5.1.7)
+    activerecord (5.1.7)
+      activemodel (= 5.1.7)
+      activesupport (= 5.1.7)
+      arel (~> 8.0)
+    activesupport (5.1.7)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    arel (6.0.4)
-    builder (3.2.4)
+    arel (8.0.0)
     bump (0.10.0)
     byebug (11.1.3)
     concurrent-ruby (1.1.9)
-    i18n (0.9.5)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     minitest (5.14.4)
     minitest-rg (5.2.0)
       minitest (~> 5.0)
     query_diet (0.7.0)
     rake (13.0.6)
-    sqlite3 (1.3.13)
+    sqlite3 (1.4.2)
     thread_safe (0.3.6)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
@@ -41,7 +39,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (~> 4.2.5)
+  activerecord (~> 5.1.1)
   bump
   byebug
   minitest
@@ -49,7 +47,7 @@ DEPENDENCIES
   predictive_load!
   query_diet
   rake
-  sqlite3 (~> 1.3, < 1.4)
+  sqlite3
   wwtd
 
 BUNDLED WITH

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -7,31 +7,29 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.11.3)
-      activesupport (= 4.2.11.3)
-      builder (~> 3.1)
-    activerecord (4.2.11.3)
-      activemodel (= 4.2.11.3)
-      activesupport (= 4.2.11.3)
-      arel (~> 6.0)
-    activesupport (4.2.11.3)
-      i18n (~> 0.7)
+    activemodel (5.2.6)
+      activesupport (= 5.2.6)
+    activerecord (5.2.6)
+      activemodel (= 5.2.6)
+      activesupport (= 5.2.6)
+      arel (>= 9.0)
+    activesupport (5.2.6)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    arel (6.0.4)
-    builder (3.2.4)
+    arel (9.0.0)
     bump (0.10.0)
     byebug (11.1.3)
     concurrent-ruby (1.1.9)
-    i18n (0.9.5)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     minitest (5.14.4)
     minitest-rg (5.2.0)
       minitest (~> 5.0)
     query_diet (0.7.0)
     rake (13.0.6)
-    sqlite3 (1.3.13)
+    sqlite3 (1.4.2)
     thread_safe (0.3.6)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
@@ -41,7 +39,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (~> 4.2.5)
+  activerecord (~> 5.2.0)
   bump
   byebug
   minitest
@@ -49,7 +47,7 @@ DEPENDENCIES
   predictive_load!
   query_diet
   rake
-  sqlite3 (~> 1.3, < 1.4)
+  sqlite3
   wwtd
 
 BUNDLED WITH

--- a/lib/predictive_load/active_record_collection_observation.rb
+++ b/lib/predictive_load/active_record_collection_observation.rb
@@ -9,8 +9,8 @@ module PredictiveLoad::ActiveRecordCollectionObservation
     end
     ActiveRecord::Base.include CollectionMember
     ActiveRecord::Base.extend UnscopedTracker
-    ActiveRecord::Associations::Association.include AssociationNotification
-    ActiveRecord::Associations::CollectionAssociation.include CollectionAssociationNotification
+    ActiveRecord::Associations::Association.prepend AssociationNotification
+    ActiveRecord::Associations::CollectionAssociation.prepend CollectionAssociationNotification
   end
 
   module Rails5RelationObservation
@@ -66,16 +66,10 @@ module PredictiveLoad::ActiveRecordCollectionObservation
   end
 
   module AssociationNotification
-
-    def self.included(base)
-      base.send(:alias_method, :load_target_without_notification, :load_target)
-      base.send(:alias_method, :load_target, :load_target_with_notification)
-    end
-
-    def load_target_with_notification
+    def load_target
       notify_collection_observer if find_target?
 
-      load_target_without_notification
+      super
     end
 
     protected
@@ -85,22 +79,14 @@ module PredictiveLoad::ActiveRecordCollectionObservation
         @owner.collection_observer.loading_association(@owner, self)
       end
     end
-
   end
 
   module CollectionAssociationNotification
-
-    def self.included(base)
-      base.send(:alias_method, :load_target_without_notification, :load_target)
-      base.send(:alias_method, :load_target, :load_target_with_notification)
-    end
-
-    def load_target_with_notification
+    def load_target
       notify_collection_observer if find_target?
 
-      load_target_without_notification
+      super
     end
-
   end
 
 end


### PR DESCRIPTION
When trying to use `bullet` along with this gem, they conflict with each other.
Switching to `prepend` and dropping the aliases solves the conflict.