### PR TITLE
Gem cleanup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,3 +7,5 @@ Rake::TestTask.new(:test) do |test|
   test.pattern = 'test/*_test.rb'
   test.verbose = true
 end
+
+task default: :test

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -217,7 +217,7 @@ describe PredictiveLoad::Loader do
           Comment.unscoped do
             expected = (ActiveRecord::VERSION::MAJOR >= 4 ? 2 : 1) # we disable preloading in unscoped blocks in rails 4 because it's broken ...
             assert_queries(expected) do
-              @users.each { |user| user.comments.to_a.map(&:public).uniq.must_equal [true, false] }
+              @users.each { |user| _(user.comments.to_a.map(&:public).uniq).must_equal [true, false] }
             end
           end
         end
@@ -225,7 +225,7 @@ describe PredictiveLoad::Loader do
         it "preloads correctly when unscoped for a different class" do
           User.unscoped do
             assert_queries(1) do
-              @users.each { |user| user.comments.to_a.map(&:public).uniq.must_equal [true] }
+              @users.each { |user| _(user.comments.to_a.map(&:public).uniq).must_equal [true] }
             end
           end
         end


### PR DESCRIPTION
### Description

Adding the default rake task back. Changing use of `must_equal` to use an expectation object.