### PR TITLE
Extract audit script from CI config

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,32 +17,5 @@ jobs:
     - uses: zendesk/setup-ruby@v1
       with:
         ruby-version: 2.6.6
-    - name: Installing bundler-audit
-      run: |
-        set -eu -o pipefail
-
-        gem install bundler-audit
-
     - name: Checking ${{ matrix.gemfile }}
-      run: |
-        set -eu -o pipefail
-
-        echo "BUNDLE_GEMFILE=$GITHUB_WORKSPACE/${{ matrix.gemfile }}" >> $GITHUB_ENV
-
-        case ${{ matrix.gemfile }} in
-          gemfiles/rails4.2.gemfile)
-            IGNORED="CVE-2021-22880 CVE-2020-8165 CVE-2020-8164 CVE-2020-8166 CVE-2021-22885 CVE-2021-22904 CVE-2020-15169 CVE-2020-5267 CVE-2020-8163 CVE-2020-8167 CVE-2020-8161 CVE-2020-8184"
-            ;;
-          gemfiles/rails5.1.gemfile)
-            IGNORED="CVE-2021-22880 CVE-2020-8165 CVE-2020-8164 CVE-2020-8166 CVE-2021-22885 CVE-2021-22904 CVE-2020-15169 CVE-2020-5267 CVE-2020-8167"
-            ;;
-          *)
-            IGNORED=""
-            ;;
-        esac
-
-        if [ -n "$IGNORED" ]; then
-          echo "::warning:: Ignored vulnerabilities: $IGNORED"
-        fi
-
-        bundle-audit check --update --gemfile-lock ${{ matrix.gemfile }}.lock --ignore $IGNORED
+      run: ./script/bundle-audit ${{ matrix.gemfile }}

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -52,7 +52,7 @@ GEM
     ruby-progressbar (1.11.0)
     sqlite3 (1.3.13)
     thread_safe (0.3.6)
-    tzinfo (1.2.9)
+    tzinfo (1.2.10)
       thread_safe (~> 0.1)
     unicode-display_width (2.0.0)
 

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -50,7 +50,7 @@ GEM
     ruby-progressbar (1.11.0)
     sqlite3 (1.3.13)
     thread_safe (0.3.6)
-    tzinfo (1.2.9)
+    tzinfo (1.2.10)
       thread_safe (~> 0.1)
     unicode-display_width (2.0.0)
 

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -50,7 +50,7 @@ GEM
     ruby-progressbar (1.11.0)
     sqlite3 (1.4.2)
     thread_safe (0.3.6)
-    tzinfo (1.2.9)
+    tzinfo (1.2.10)
       thread_safe (~> 0.1)
     unicode-display_width (2.0.0)
 

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -7,13 +7,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.6)
-      activesupport (= 5.2.6)
-    activerecord (5.2.6)
-      activemodel (= 5.2.6)
-      activesupport (= 5.2.6)
+    activemodel (5.2.8.1)
+      activesupport (= 5.2.8.1)
+    activerecord (5.2.8.1)
+      activemodel (= 5.2.8.1)
+      activesupport (= 5.2.8.1)
       arel (>= 9.0)
-    activesupport (5.2.6)
+    activesupport (5.2.8.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -50,7 +50,7 @@ GEM
     ruby-progressbar (1.11.0)
     sqlite3 (1.4.2)
     thread_safe (0.3.6)
-    tzinfo (1.2.9)
+    tzinfo (1.2.10)
       thread_safe (~> 0.1)
     unicode-display_width (2.0.0)
 

--- a/script/bundle-audit
+++ b/script/bundle-audit
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+set -eu
+
+GEMFILE="$1"
+
+gem install bundler-audit
+
+case $GEMFILE in
+
+  gemfiles/rails4.2.gemfile)
+    IGNORED="CVE-2021-22880 CVE-2022-32224 CVE-2020-8165"
+    ;;
+  gemfiles/rails5.0.gemfile)
+    IGNORED="CVE-2021-22880 CVE-2022-32224 CVE-2020-8165"
+    ;;
+  gemfiles/rails5.1.gemfile)
+    IGNORED="CVE-2021-22880 CVE-2022-32224 CVE-2020-8165"
+    ;;
+  gemfiles/rails5.2.gemfile)
+    IGNORED=""
+    ;;
+  *)
+    echo unsupported gemfile: $GEMFILE
+    exit 1
+    ;;
+esac
+
+if [ -n "$IGNORED" ]; then
+  echo "::warning:: Ignored vulnerabilities: $IGNORED"
+  bundle-audit check --update --gemfile-lock $GEMFILE.lock --ignore $IGNORED
+else
+  bundle-audit check --update --gemfile-lock $GEMFILE.lock
+fi


### PR DESCRIPTION
### Description

Doing other work, CI was failing on the bundle-audit job. The script wasn't written for local execution, so I extracted it into `./script/bundle-audit`, and made a few modifications:

- first argument to the script (`$1`) is the gemspec path,
- the list of CVEs is split by Rails minor version, and
- a few Rails-specific CVEs were added to the ignore lists for 4.2, 5.0 and 5.1.

Following that, all the vulnerable gems have been upgraded.

