### PR TITLE
Clean up a bit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ DEPENDENCIES
   query_diet
   rake
   rubocop
-  sqlite3 (~> 1.3, < 1.4)
+  sqlite3 (~> 1.3.6)
 
 BUNDLED WITH
    1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,4 +72,4 @@ DEPENDENCIES
   sqlite3 (~> 1.3.6)
 
 BUNDLED WITH
-   1.17.3
+   2.3.21

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,4 +1,4 @@
 eval_gemfile('common.rb')
 
 gem 'activerecord', '~> 4.2.5'
-gem 'sqlite3', '~> 1.3', '< 1.4'
+gem 'sqlite3', '~> 1.3.6'

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -69,7 +69,7 @@ DEPENDENCIES
   query_diet
   rake
   rubocop
-  sqlite3 (~> 1.3, < 1.4)
+  sqlite3 (~> 1.3.6)
 
 BUNDLED WITH
    1.17.3

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -72,4 +72,4 @@ DEPENDENCIES
   sqlite3 (~> 1.3.6)
 
 BUNDLED WITH
-   1.17.3
+   2.3.21

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,4 +1,4 @@
 eval_gemfile('common.rb')
 
-gem 'activerecord', '~>5.0.0'
-gem 'sqlite3', '~> 1.3', '< 1.4'
+gem 'activerecord', '~> 5.0.0'
+gem 'sqlite3', '~> 1.3.6'

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -67,7 +67,7 @@ DEPENDENCIES
   query_diet
   rake
   rubocop
-  sqlite3 (~> 1.3, < 1.4)
+  sqlite3 (~> 1.3.6)
 
 BUNDLED WITH
    1.17.3

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -70,4 +70,4 @@ DEPENDENCIES
   sqlite3 (~> 1.3.6)
 
 BUNDLED WITH
-   1.17.3
+   2.3.21

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -1,4 +1,4 @@
 eval_gemfile('common.rb')
 
-gem 'activerecord', '~> 5.1.1', require: 'active_record'
-gem 'sqlite3'
+gem 'activerecord', '~> 5.1.1'
+gem 'sqlite3', '~> 1.3', '>= 1.3.6'

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -70,4 +70,4 @@ DEPENDENCIES
   sqlite3 (~> 1.3, >= 1.3.6)
 
 BUNDLED WITH
-   1.17.3
+   2.3.21

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -67,7 +67,7 @@ DEPENDENCIES
   query_diet
   rake
   rubocop
-  sqlite3
+  sqlite3 (~> 1.3, >= 1.3.6)
 
 BUNDLED WITH
    1.17.3

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -1,4 +1,4 @@
 eval_gemfile('common.rb')
 
-gem 'activerecord', '~> 5.2.0', require: 'active_record'
-gem 'sqlite3'
+gem 'activerecord', '~> 5.2.0'
+gem 'sqlite3', '~> 1.3', '>= 1.3.6'

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -70,4 +70,4 @@ DEPENDENCIES
   sqlite3 (~> 1.3, >= 1.3.6)
 
 BUNDLED WITH
-   1.17.3
+   2.3.21

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -67,7 +67,7 @@ DEPENDENCIES
   query_diet
   rake
   rubocop
-  sqlite3
+  sqlite3 (~> 1.3, >= 1.3.6)
 
 BUNDLED WITH
    1.17.3

--- a/lib/predictive_load.rb
+++ b/lib/predictive_load.rb
@@ -2,17 +2,8 @@ module PredictiveLoad
 
 end
 
-klasses = [ActiveRecord::Associations::Builder::Association]
-
-if ActiveRecord::VERSION::MAJOR == 3
-  # when belongs_to etc is loaded before us it already made a copy of valid_options
-  klasses.concat ActiveRecord::Associations::Builder::Association.descendants
-end
-
-klasses.each do |klass|
-  if ActiveRecord::VERSION::MAJOR < 5
-    klass.valid_options << :predictive_load
-  else
-    klass::VALID_OPTIONS << :predictive_load
-  end
+if ActiveRecord::VERSION::MAJOR >= 5
+  ActiveRecord::Associations::Builder::Association::VALID_OPTIONS << :predictive_load
+else
+  ActiveRecord::Associations::Builder::Association.valid_options << :predictive_load
 end

--- a/lib/predictive_load/active_record_collection_observation.rb
+++ b/lib/predictive_load/active_record_collection_observation.rb
@@ -45,18 +45,16 @@ module PredictiveLoad::ActiveRecordCollectionObservation
 
   # disable eager loading since includes + unscoped is broken on rails 4
   module UnscopedTracker
-    if ActiveRecord::VERSION::MAJOR >= 4
-      def unscoped
-        if block_given?
-          begin
-            predictive_load_disabled << self
-            super
-          ensure
-            predictive_load_disabled.pop
-          end
-        else
+    def unscoped
+      if block_given?
+        begin
+          predictive_load_disabled << self
           super
+        ensure
+          predictive_load_disabled.pop
         end
+      else
+        super
       end
     end
 

--- a/lib/predictive_load/loader.rb
+++ b/lib/predictive_load/loader.rb
@@ -43,7 +43,7 @@ module PredictiveLoad
       return false if ActiveRecord::Base.predictive_load_disabled.include?(association.klass)
       return false if association.reflection.options[:predictive_load] == false
       return false if association.reflection.options[:conditions].respond_to?(:to_proc) # rails 3 conditions proc (we do not know if it uses instance methods)
-      if ActiveRecord::VERSION::MAJOR > 3 && scope = association.reflection.scope
+      if scope = association.reflection.scope
         if scope.is_a?(Proc)
           # rails 4+ conditions block, if it uses a passed in object, we assume it is not preloadable
           return false if scope.arity.to_i > 0
@@ -68,11 +68,7 @@ module PredictiveLoad
       #
       # Fix is pretty simple, ignore any record with association already loaded.
       rs = records_with_association(association_name).reject { |r| r.association(association_name).loaded? }
-      if ActiveRecord::VERSION::STRING <= "4.1.0"
-        ActiveRecord::Associations::Preloader.new(rs, [ association_name ]).run
-      else
-        ActiveRecord::Associations::Preloader.new.preload(rs, [ association_name ])
-      end
+      ActiveRecord::Associations::Preloader.new.preload(rs, [ association_name ])
     end
 
     def records_with_association(association_name)

--- a/lib/predictive_load/preload_log.rb
+++ b/lib/predictive_load/preload_log.rb
@@ -8,16 +8,14 @@ module PredictiveLoad
     def preload(association)
       grouped_records(association).each do |reflection, klasses|
         klasses.each do |klass, records|
-          preload_scope = (ActiveRecord::VERSION::MAJOR == 3 ? options : self.preload_scope)
-          preloader   = preloader_for(reflection).new(klass, records, reflection, preload_scope)
+          preloader = preloader_for(reflection).new(klass, records, reflection, preload_scope)
 
           if preloader.respond_to?(:through_reflection)
             log("encountered :through association for #{association}. Requires loading records to generate query, so skipping for now.")
             next
           end
 
-          scope = (ActiveRecord::VERSION::MAJOR == 3 ? preloader.scoped : preloader.scope)
-          preload_sql = scope.where(collection_arel(preloader)).to_sql
+          preload_sql = preloader.scope.where(collection_arel(preloader)).to_sql
 
           log("would preload with: #{preload_sql.to_s}")
           klass.connection.explain(preload_sql).each_line do |line|

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -76,24 +76,6 @@ describe PredictiveLoad::Loader do
         end
       end
 
-      it "preloads with static conditions" do
-        skip "Unsupported syntax"
-        comments = Comment.all.to_a
-        assert_equal 2, comments.size
-        assert_queries(1) do
-          comments.each { |comment| assert comment.user_with_static_conditions.name }
-        end
-      end
-
-      it "does not attempt to preload associations with proc conditions" do
-        skip "Unsupported syntax"
-        comments = Comment.all.to_a
-        assert_equal 2, comments.size
-        assert_queries(2) do
-          comments.each { |comment| assert comment.user_by_proc.full_name }
-        end
-      end
-
       it "does not attempt to preload associations with proc that has arguments / uses instance" do
         comments = Comment.all.to_a
         assert_equal 2, comments.size
@@ -232,14 +214,6 @@ describe PredictiveLoad::Loader do
           topic = Topic.first
           assert_queries(2) do
             users.each { |user| user.comments.by_topic(topic).to_a }
-          end
-        end
-
-        it "does not preload when staticly scoped" do
-          skip "this only caches on rails 4.0 ... and is removed in rails 4.1+"
-          users = User.all.to_a
-          assert_queries(2) do
-            users.each { |user| user.comments.recent.to_a }
           end
         end
 

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -77,7 +77,7 @@ describe PredictiveLoad::Loader do
       end
 
       it "preloads with static conditions" do
-        skip "Unsupported syntax" if ActiveRecord::VERSION::STRING > "4.1.0"
+        skip "Unsupported syntax"
         comments = Comment.all.to_a
         assert_equal 2, comments.size
         assert_queries(1) do
@@ -86,7 +86,7 @@ describe PredictiveLoad::Loader do
       end
 
       it "does not attempt to preload associations with proc conditions" do
-        skip "Unsupported syntax" if ActiveRecord::VERSION::STRING > "4.1.0"
+        skip "Unsupported syntax"
         comments = Comment.all.to_a
         assert_equal 2, comments.size
         assert_queries(2) do
@@ -95,7 +95,6 @@ describe PredictiveLoad::Loader do
       end
 
       it "does not attempt to preload associations with proc that has arguments / uses instance" do
-        skip "Unsupported syntax" if ActiveRecord::VERSION::MAJOR == 3
         comments = Comment.all.to_a
         assert_equal 2, comments.size
         assert_queries(2) do
@@ -104,7 +103,6 @@ describe PredictiveLoad::Loader do
       end
 
       it "does attempt to preload associations with proc that have no arguments / does not use instance" do
-        skip "Unsupported syntax" if ActiveRecord::VERSION::MAJOR == 3
         comments = Comment.all.to_a
         assert_equal 2, comments.size
         assert_queries(1) do
@@ -154,9 +152,7 @@ describe PredictiveLoad::Loader do
         assert_equal 3, users.size
         users.each { |user| EmailsUser.create!(user_id: user.id, email_id: Email.create!.id) }
 
-        expected = (ActiveRecord::VERSION::STRING < "4.1.0" ? 1 : 2) # did a join before, now does 2 queries
-
-        assert_queries(expected) do
+        assert_queries(2) do
           users.each { |user| user.emails.to_a }
         end
       end
@@ -215,8 +211,7 @@ describe PredictiveLoad::Loader do
         it "preloads correctly when unscoped for eager loaded class" do
           # when eager loading inside of unscoped the private comment should show up
           Comment.unscoped do
-            expected = (ActiveRecord::VERSION::MAJOR >= 4 ? 2 : 1) # we disable preloading in unscoped blocks in rails 4 because it's broken ...
-            assert_queries(expected) do
+            assert_queries(2) do
               @users.each { |user| _(user.comments.to_a.map(&:public).uniq).must_equal [true, false] }
             end
           end
@@ -241,7 +236,7 @@ describe PredictiveLoad::Loader do
         end
 
         it "does not preload when staticly scoped" do
-          skip "this only caches on rails 4.0 ... and is removed in rails 4.1+" if ActiveRecord::VERSION::STRING >= "4.0.0"
+          skip "this only caches on rails 4.0 ... and is removed in rails 4.1+"
           users = User.all.to_a
           assert_queries(2) do
             users.each { |user| user.comments.recent.to_a }
@@ -249,7 +244,6 @@ describe PredictiveLoad::Loader do
         end
 
         it "does not preload when block scoped" do
-          skip "Unsupported syntax" if ActiveRecord::VERSION::MAJOR == 3
           users = User.all.to_a
           assert_queries(2) do
             users.each { |user| user.comments.recent_v2.to_a }

--- a/test/models.rb
+++ b/test/models.rb
@@ -24,22 +24,11 @@ class Comment < ActiveRecord::Base
   default_scope { where(public: true) }
   belongs_to :user
 
-  unless ActiveRecord::VERSION::STRING > "4.1.0"
-    ActiveSupport::Deprecation.silence do
-      block = (ActiveRecord::VERSION::MAJOR == 3 ? proc { "1 = #{one}" } : proc { |object| "1 = #{object.one}" })
-      belongs_to :user_by_proc, :class_name => "User", :foreign_key => :user_id, :conditions => block
+  belongs_to :user_by_proc_v2,
+    proc { |object| where("1 = #{object.one}") }, :class_name => "User", :foreign_key => :user_id
 
-      belongs_to :user_with_static_conditions, :class_name => "User", :foreign_key => :user_id, :conditions => "1 = 1"
-    end
-  end
-
-  if ActiveRecord::VERSION::MAJOR > 3
-    belongs_to :user_by_proc_v2,
-      proc { |object| where("1 = #{ActiveRecord::VERSION::MAJOR == 3 ? one : object.one}") }, :class_name => "User", :foreign_key => :user_id
-
-    belongs_to :user_by_proc_v2_no_args,
-      proc { where("1 = 1") }, :class_name => "User", :foreign_key => :user_id
-  end
+  belongs_to :user_by_proc_v2_no_args,
+    proc { where("1 = 1") }, :class_name => "User", :foreign_key => :user_id
 
   belongs_to :user_no_preload,
     :class_name => "User", :foreign_key => :user_id, :predictive_load => false
@@ -47,11 +36,7 @@ class Comment < ActiveRecord::Base
   belongs_to :topic
 
   scope :by_topic, lambda { |topic| where(:topic_id => topic.id) }
-  if ActiveRecord::VERSION::MAJOR == 3
-    scope :recent, order('updated_at desc')
-  else
-    scope :recent, -> { order('updated_at desc') }
-  end
+  scope :recent, -> { order('updated_at desc') }
   scope :recent_v2, lambda { order('updated_at desc') }
 
   def one


### PR DESCRIPTION
Mostly removal of unnecessary comparisons with `ActiveRecord::VERSION`. The gemspec guarantees that we won’t encounter anything lower than 4.2.