### PR TITLE
CI: Fix bundle-audit failures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,10 +22,10 @@ GEM
     bump (0.10.0)
     byebug (11.1.3)
     concurrent-ruby (1.2.2)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     mini_portile2 (2.8.1)
-    minitest (5.14.4)
+    minitest (5.18.1)
     minitest-rg (5.2.0)
       minitest (~> 5.0)
     parallel (1.20.1)
@@ -54,7 +54,7 @@ GEM
     tzinfo (1.2.11)
       thread_safe (~> 0.1)
     unicode-display_width (2.0.0)
-    zeitwerk (2.6.7)
+    zeitwerk (2.6.11)
 
 PLATFORMS
   ruby

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     predictive_load (0.7.0)
-      activerecord (>= 6.0.0, < 7.1)
+      activerecord (>= 6.0, < 7.1)
 
 GEM
   remote: https://rubygems.org/
@@ -21,12 +21,12 @@ GEM
     ast (2.4.2)
     bump (0.10.0)
     byebug (11.1.3)
-    concurrent-ruby (1.1.10)
-    i18n (1.12.0)
+    concurrent-ruby (1.2.2)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.6.2)
     mini_portile2 (2.8.0)
-    minitest (5.16.3)
+    minitest (5.18.1)
     minitest-rg (5.2.0)
       minitest (~> 5.0)
     parallel (1.22.1)
@@ -53,10 +53,10 @@ GEM
     sqlite3 (1.5.1)
       mini_portile2 (~> 2.8.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.10)
+    tzinfo (1.2.11)
       thread_safe (~> 0.1)
     unicode-display_width (2.3.0)
-    zeitwerk (2.6.0)
+    zeitwerk (2.6.11)
 
 PLATFORMS
   ruby

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -2,17 +2,17 @@ PATH
   remote: ..
   specs:
     predictive_load (0.7.0)
-      activerecord (>= 6.0.0, < 7.1)
+      activerecord (>= 6.0, < 7.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.7.3)
-      activesupport (= 6.1.7.3)
-    activerecord (6.1.7.3)
-      activemodel (= 6.1.7.3)
-      activesupport (= 6.1.7.3)
-    activesupport (6.1.7.3)
+    activemodel (6.1.7.6)
+      activesupport (= 6.1.7.6)
+    activerecord (6.1.7.6)
+      activemodel (= 6.1.7.6)
+      activesupport (= 6.1.7.6)
+    activesupport (6.1.7.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -21,12 +21,12 @@ GEM
     ast (2.4.2)
     bump (0.10.0)
     byebug (11.1.3)
-    concurrent-ruby (1.1.10)
-    i18n (1.12.0)
+    concurrent-ruby (1.2.2)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.6.2)
     mini_portile2 (2.8.0)
-    minitest (5.16.3)
+    minitest (5.18.1)
     minitest-rg (5.2.0)
       minitest (~> 5.0)
     parallel (1.22.1)
@@ -52,10 +52,10 @@ GEM
     ruby-progressbar (1.11.0)
     sqlite3 (1.5.1)
       mini_portile2 (~> 2.8.0)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)
-    zeitwerk (2.6.0)
+    zeitwerk (2.6.11)
 
 PLATFORMS
   ruby

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -2,17 +2,17 @@ PATH
   remote: ..
   specs:
     predictive_load (0.7.0)
-      activerecord (>= 6.0.0, < 7.1)
+      activerecord (>= 6.0, < 7.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.0.4.3)
-      activesupport (= 7.0.4.3)
-    activerecord (7.0.4.3)
-      activemodel (= 7.0.4.3)
-      activesupport (= 7.0.4.3)
-    activesupport (7.0.4.3)
+    activemodel (7.0.7.2)
+      activesupport (= 7.0.7.2)
+    activerecord (7.0.7.2)
+      activemodel (= 7.0.7.2)
+      activesupport (= 7.0.7.2)
+    activesupport (7.0.7.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -20,12 +20,12 @@ GEM
     ast (2.4.2)
     bump (0.10.0)
     byebug (11.1.3)
-    concurrent-ruby (1.1.10)
-    i18n (1.12.0)
+    concurrent-ruby (1.2.2)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.6.2)
     mini_portile2 (2.8.0)
-    minitest (5.16.3)
+    minitest (5.18.1)
     minitest-rg (5.2.0)
       minitest (~> 5.0)
     parallel (1.22.1)
@@ -51,7 +51,7 @@ GEM
     ruby-progressbar (1.11.0)
     sqlite3 (1.5.1)
       mini_portile2 (~> 2.8.0)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)
 

--- a/script/bundle-audit
+++ b/script/bundle-audit
@@ -9,7 +9,7 @@ gem install bundler-audit
 case $GEMFILE in
 
   gemfiles/rails6.0.gemfile)
-    IGNORED="CVE-2023-28120 CVE-2022-44566 CVE-2023-22796"
+    IGNORED="CVE-2023-28120 CVE-2022-44566 CVE-2023-22796 CVE-2023-38037"
     ;;
   gemfiles/rails6.1.gemfile)
     IGNORED=""


### PR DESCRIPTION
CVE-2023-38037 says we should upgrade to ActiveRecord v6.1, so we ignore that for v6.0.*. The other CVEs can be fixed by upgrading the bundled version of ActiveRecord.
