### PR TITLE
use standard gem rules via rubocop so regular integrations work

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: test
+      - name: rake test
         run: bundle exec rake test
   validate:
     runs-on: ubuntu-latest
@@ -39,5 +39,5 @@ jobs:
         with:
           ruby-version: '2.7'
           bundler-cache: true
-      - name: StandardRb
-        run: bundle exec standardrb
+      - name: rake fmt
+        run: bundle exec rake fmt

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,11 @@
+require:
+- standard
+
+inherit_gem:
+  standard: config/base.yml
+
+AllCops:
+  SuggestExtensions: false
+  TargetRubyVersion: 2.7
+  Exclude:
+  - vendor/**/*

--- a/Rakefile
+++ b/Rakefile
@@ -2,13 +2,15 @@ require "bundler/setup"
 require "bundler/gem_tasks"
 require "rake/testtask"
 require "bump/tasks"
-require "standard/rake"
 
-task lint: :standard
+desc "Format code"
+task :fmt do
+  sh "rubocop --auto-correct"
+end
 
 Rake::TestTask.new(:test) do |test|
   test.pattern = "test/*_test.rb"
   test.verbose = true
 end
 
-task default: [:test, :lint]
+task default: [:test, :fmt]


### PR DESCRIPTION
- no need to learn how standard tasks/internals work
- ide / cli integrations still work fine since they recognize .rubocop.yml

builds on https://github.com/zendesk/predictive_load/pull/33

/cc @bquorning 