### PR TITLE
Change CI to run on push

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,11 +1,6 @@
 name: Continuous Integration
-on:
-  pull_request:
-    branches:
-      - master
-  push:
-    branches:
-      - master
+on: push
+
 jobs:
   specs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Doesn't tie us to a specific branch name and starts running the test suite immediately.
