### PR TITLE
stop setting ENV["gem_push"] to false

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,9 +3,6 @@ require "bundler/gem_tasks"
 require "rake/testtask"
 require "bump/tasks"
 
-# Pushing to rubygems is handled by a github workflow
-ENV["gem_push"] = "false"
-
 desc "Format code"
 task :fmt do
   sh "rubocop --auto-correct"


### PR DESCRIPTION
Publishing workflow now uses `rake release` again, so we don’t want to prevent that task from pushing to RubyGems.


